### PR TITLE
feat: Tailwind v4 support, v3 and v4 tabs

### DIFF
--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -3,8 +3,14 @@
 import React from "react"
 import { CheckIcon, CopyIcon } from "lucide-react"
 
-import { getCopyableCssVariables } from "@/lib/utils"
-import { useGeneratedColors } from "@/hooks/use-generated-colors"
+import {
+  getCopyableCssVariablesV3,
+  getCopyableCssVariablesV4,
+} from "@/lib/utils"
+import {
+  useGeneratedColorsV3,
+  useGeneratedColorsV4,
+} from "@/hooks/use-generated-colors"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -22,15 +28,26 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs"
+
 export default function CopyButton() {
   const [isCopied, setIsCopied] = React.useState(false)
-  const colors = useGeneratedColors()
+  const [themeVersion, setThemeVersion] = React.useState<"v3" | "v4">("v3")
+  const colorsV3 = useGeneratedColorsV3()
+  const colorsV4 = useGeneratedColorsV4()
 
   function onCopy() {
     setIsCopied(true)
     setTimeout(() => setIsCopied(false), 2000)
 
-    navigator.clipboard.writeText(getCopyableCssVariables(colors))
+    switch (themeVersion) {
+      case "v3":
+        navigator.clipboard.writeText(getCopyableCssVariablesV3(colorsV3))
+        break
+      case "v4":
+        navigator.clipboard.writeText(getCopyableCssVariablesV4(colorsV4))
+        break
+    }
   }
 
   return (
@@ -48,19 +65,29 @@ export default function CopyButton() {
             Copy and paste the following code into your CSS file.
           </DialogDescription>
         </DialogHeader>
-        <ScrollArea className="bg-card rounded-lg border max-h-[50vh] relative">
-          <Button
-            onClick={onCopy}
-            className="absolute right-4 top-4 gap-2"
-            variant="secondary"
-          >
-            {isCopied ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
-            <span>Copy</span>
-          </Button>
-          <pre className="text-sm p-4 leading-normal">
-            {getCopyableCssVariables(colors)}
-          </pre>
-        </ScrollArea>
+        <Tabs onValueChange={(value: any) => setThemeVersion(value)}>
+          <div className="flex items-center justify-between mb-2">
+            <TabsList>
+              <TabsTrigger value="v3">v3</TabsTrigger>
+              <TabsTrigger value="v4">v4</TabsTrigger>
+            </TabsList>
+            <Button
+              onClick={onCopy}
+              className="gap-2"
+              variant="secondary"
+              size="sm"
+            >
+              {isCopied ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+              <span>Copy</span>
+            </Button>
+          </div>
+          <ScrollArea className="bg-card rounded-lg border max-h-[50vh] relative overflow-auto">
+            <pre className="text-sm p-4 leading-normal">
+              {themeVersion == "v3" && getCopyableCssVariablesV3(colorsV3)}
+              {themeVersion == "v4" && getCopyableCssVariablesV4(colorsV4)}
+            </pre>
+          </ScrollArea>
+        </Tabs>
       </DialogContent>
     </Dialog>
   )

--- a/components/theme-sync.tsx
+++ b/components/theme-sync.tsx
@@ -3,10 +3,10 @@
 import React from "react"
 import { useTheme } from "next-themes"
 
-import { useGeneratedColors } from "@/hooks/use-generated-colors"
+import { useGeneratedColorsV3 } from "@/hooks/use-generated-colors"
 
 export function ThemeSync() {
-  const generatedColors = useGeneratedColors()
+  const generatedColors = useGeneratedColorsV3()
   const { resolvedTheme } = useTheme()
 
   React.useEffect(() => {

--- a/hooks/use-generated-colors.ts
+++ b/hooks/use-generated-colors.ts
@@ -1,13 +1,23 @@
 import React from "react"
 
-import { generateTheme } from "@/utils/theme-generator"
+import { generateThemeV3, generateThemeV4 } from "@/utils/theme-generator"
 import { useColorStore } from "@/store/color-store"
 
-export function useGeneratedColors() {
+export function useGeneratedColorsV3() {
   const lightOptions = useColorStore((state) => state.light)
   const darkOptions = useColorStore((state) => state.dark)
   const colors = React.useMemo(
-    () => generateTheme({ lightOptions, darkOptions }),
+    () => generateThemeV3({ lightOptions, darkOptions }),
+    [lightOptions, darkOptions]
+  )
+  return colors
+}
+
+export function useGeneratedColorsV4() {
+  const lightOptions = useColorStore((state) => state.light)
+  const darkOptions = useColorStore((state) => state.dark)
+  const colors = React.useMemo(
+    () => generateThemeV4({ lightOptions, darkOptions }),
     [lightOptions, darkOptions]
   )
   return colors

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,6 +37,22 @@ export function convertAllHexToCssVar(obj: ColorVariables) {
   return result
 }
 
+export function convertHexToCssHslVar(hex: string) {
+  const [h, s, l] = convert.hex.hsl(hex)
+  return `hsl(${h}, ${s}%, ${l}%)`
+}
+
+export function convertAllHexToCssHslVar(obj: ColorVariables) {
+  const result = { ...obj }
+
+  for (const k in obj) {
+    const key = k as keyof ColorVariables
+    result[key] = convertHexToCssHslVar(result[key])
+  }
+
+  return result
+}
+
 export function isValidColor(color: string) {
   try {
     Color(color)
@@ -44,7 +60,7 @@ export function isValidColor(color: string) {
   } catch (error) {}
 }
 
-export function getCopyableCssVariables({
+export function getCopyableCssVariablesV3({
   light,
   dark,
 }: {
@@ -113,5 +129,75 @@ export function getCopyableCssVariables({
     --input: ${dark["--input"]};
     --ring: ${dark["--ring"]};
   }
+}`
+}
+
+export function getCopyableCssVariablesV4({
+  light,
+  dark,
+}: {
+  light: ColorVariables
+  dark: ColorVariables
+}) {
+  return `:root {
+  --background: ${light["--background"]};
+  --foreground: ${light["--foreground"]};
+
+  --card: ${light["--card"]};
+  --card-foreground: ${light["--card-foreground"]};
+
+  --popover: ${light["--popover"]};
+  --popover-foreground: ${light["--popover-foreground"]};
+
+  --primary: ${light["--primary"]};
+  --primary-foreground: ${light["--primary-foreground"]};
+
+  --secondary: ${light["--secondary"]};
+  --secondary-foreground: ${light["--secondary-foreground"]};
+
+  --muted: ${light["--muted"]};
+  --muted-foreground: ${light["--muted-foreground"]};
+
+  --accent: ${light["--accent"]};
+  --accent-foreground: ${light["--accent-foreground"]};
+
+  --destructive: ${light["--destructive"]};
+  --destructive-foreground: ${light["--destructive-foreground"]};
+
+  --border: ${light["--border"]};
+  --input: ${light["--input"]};
+  --ring: ${light["--ring"]};
+
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: ${dark["--background"]};
+  --foreground: ${dark["--foreground"]};
+
+  --card: ${dark["--card"]};
+  --card-foreground: ${dark["--card-foreground"]};
+
+  --popover: ${dark["--popover"]};
+  --popover-foreground: ${dark["--popover-foreground"]};
+
+  --primary: ${dark["--primary"]};
+  --primary-foreground: ${dark["--primary-foreground"]};
+
+  --secondary: ${dark["--secondary"]};
+  --secondary-foreground: ${dark["--secondary-foreground"]};
+
+  --muted: ${dark["--muted"]};
+  --muted-foreground: ${dark["--muted-foreground"]};
+
+  --accent: ${dark["--accent"]};
+  --accent-foreground: ${dark["--accent-foreground"]};
+
+  --destructive: ${dark["--destructive"]};
+  --destructive-foreground: ${dark["--destructive-foreground"]};
+
+  --border: ${dark["--border"]};
+  --input: ${dark["--input"]};
+  --ring: ${dark["--ring"]};
 }`
 }

--- a/utils/theme-generator.ts
+++ b/utils/theme-generator.ts
@@ -1,7 +1,11 @@
 import Color from "color"
 
 import { ColorVariables } from "@/types/colors"
-import { convertAllHexToCssVar, convertCssVarToHex } from "@/lib/utils"
+import {
+  convertAllHexToCssHslVar,
+  convertAllHexToCssVar,
+  convertCssVarToHex,
+} from "@/lib/utils"
 import { DarkOptions, LightOptions } from "@/store/color-store"
 
 function isWOBG(color: Color) {
@@ -284,7 +288,7 @@ function generateDarkTheme(options: DarkOptions): ColorVariables {
   }
 }
 
-export function generateTheme({
+export function generateThemeV3({
   lightOptions,
   darkOptions,
 }: {
@@ -294,5 +298,18 @@ export function generateTheme({
   return {
     light: convertAllHexToCssVar(generateLightTheme(lightOptions)),
     dark: convertAllHexToCssVar(generateDarkTheme(darkOptions)),
+  }
+}
+
+export function generateThemeV4({
+  lightOptions,
+  darkOptions,
+}: {
+  lightOptions: LightOptions
+  darkOptions: DarkOptions
+}) {
+  return {
+    light: convertAllHexToCssHslVar(generateLightTheme(lightOptions)),
+    dark: convertAllHexToCssHslVar(generateDarkTheme(darkOptions)),
   }
 }


### PR DESCRIPTION
The current version (v3) uses HSL colors in the `h s% l%` format but no longer works on Tailwind v4. This pull request adds support for v4 with the `hsl(h, s%, l%)` format. The user can switch between the two versions when copying the css.


https://github.com/user-attachments/assets/646ba581-9ce2-479b-b647-aee0e66e4675

